### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-offline-queue",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Simple offline queue for redux, inspired by redux-queue-offline.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Package was not properly built before publishing on `v1.0.5` therefore it was a broken version. This bump in version replaces 1.0.5